### PR TITLE
Add meta tags with title and description.

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <head>
         <title>Is there a game night this week?</title>
         <link type="text/css" rel="stylesheet" href="/resources/main.css" />
+        <meta property="og:title" content="Is there a game night this week?" />
+        {% if status == 'Yes' %}
+            <meta property="og:description" content="*Yes.* {{ where }} {{ when }} {{ notes }}" />
+        {% else %}
+            <meta property="og:description" content="*{{ status }}.*" />
+        {% endif %}
     </head>
     <body>
         <div class="center">


### PR DESCRIPTION
This will make the link unfurl properly in Slack, and probably also other places. I followed the syntax elsewhere in the template but I'm not particularly familiar with it, so please double-check me. :)